### PR TITLE
update task_generator.rb to prefer a project-defined template

### DIFF
--- a/lib/generators/schlepper/task_generator.rb
+++ b/lib/generators/schlepper/task_generator.rb
@@ -4,7 +4,14 @@ module Schlepper
 
     def onetime_script
       @now = Time.now
-      template 'onetime_script.rb.erb', "#{Paths::TASK_DIR}/#{timestamped_task_name}.rb"
+      template(template_file, "#{Paths::TASK_DIR}/#{timestamped_task_name}.rb")
+    end
+
+    def template_file
+      project_template = File.join(Rails.root, ::Schlepper::Paths::TASK_DIR, 'template.rb.erb')
+      default_template = File.expand_path('../templates/onetime_script.rb.erb', __FILE__)
+
+      File.exist?(project_template) ? project_template :default_template
     end
 
     def stringified_timestamp

--- a/lib/generators/schlepper/task_generator.rb
+++ b/lib/generators/schlepper/task_generator.rb
@@ -8,7 +8,7 @@ module Schlepper
     end
 
     def template_file
-      project_template = File.join(Rails.root, ::Schlepper::Paths::TASK_DIR, 'template.rb.erb')
+      project_template = File.join(Rails.root, ::Schlepper::Paths::TASK_DIR, 'templates', 'task.rb.erb')
       default_template = File.expand_path('../templates/onetime_script.rb.erb', __FILE__)
 
       File.exist?(project_template) ? project_template :default_template


### PR DESCRIPTION
Updates the task generator to use a template defined at `schleppers/templates/task.rb.erb` instead of the gem's default, if such a file exists.